### PR TITLE
Supported some apis

### DIFF
--- a/src/mackerel.coffee
+++ b/src/mackerel.coffee
@@ -4,6 +4,7 @@
 # Commands:
 #   hubot mackerel hosts - show all hosts and graph urls
 #   hubot mackerel hosts [service <service>] [role <role>] [name <name>] [status <status>] - show hosts and graph urls filterd by specified service, role, name or status
+#   hubot mackerel host <hostId> - show detail information about the host
 #   hubot mackerel status <hostId> <standby|working|maintenance|poweroff> - update status of the host
 #   hubot mackerel retire <hostId> - retuire the host
 #
@@ -142,3 +143,26 @@ module.exports = (robot) ->
         if !response.success
           msg.send "Failed to retire host: #{host_id}"
         msg.send "host #{host_id} retired"
+
+  robot.respond /mackerel host (\w+)/i, (msg) ->
+    unless checkToken(msg)
+      return
+    unless checkEndpoint(msg)
+      return
+    unless checkUrlBase(msg)
+      return
+
+    host_id = msg.match[1]
+
+    if !host_id
+      msg.send "No host_id specified"
+
+    headers =
+      "X-Api-Key": process.env.HUBOT_MACKEREL_API_KEY
+
+    msg.http(process.env.HUBOT_MACKEREL_API_ENDPOINT + "hosts/#{host_id}")
+      .headers(headers)
+      .get() handleResponse  msg, (response) ->
+        if !response.host
+          msg.send "Failed to get host information: #{host_id}"
+        msg.send JSON.stringify response.host, null, 2

--- a/src/mackerel.coffee
+++ b/src/mackerel.coffee
@@ -5,6 +5,7 @@
 #   hubot mackerel hosts - show all hosts and graph urls
 #   hubot mackerel hosts [service <service>] [role <role>] [name <name>] [status <status>] - show hosts and graph urls filterd by specified service, role, name or status
 #   hubot mackerel status <hostId> <standby|working|maintenance|poweroff> - update status of the host
+#   hubot mackerel retire <hostId> - retuire the host
 #
 # Author:
 #   mdoi
@@ -116,3 +117,28 @@ module.exports = (robot) ->
         if !response.success
           msg.send "Failed to update status: #{host_id} to #{status}"
         msg.send "Status of #{host_id} is updated to #{status}"
+
+  robot.respond /mackerel retire (\w+)/i, (msg) ->
+    unless checkToken(msg)
+      return
+    unless checkEndpoint(msg)
+      return
+    unless checkUrlBase(msg)
+      return
+
+    host_id = msg.match[1]
+
+    if !host_id
+      msg.send "No host_id specified"
+
+    post_content = JSON.stringify({})
+    headers =
+      "X-Api-Key": process.env.HUBOT_MACKEREL_API_KEY
+      "Content-Type": "application/json"
+
+    msg.http(process.env.HUBOT_MACKEREL_API_ENDPOINT + "hosts/#{host_id}/retire")
+      .headers(headers)
+      .post(post_content) handleResponse  msg, (response) ->
+        if !response.success
+          msg.send "Failed to retire host: #{host_id}"
+        msg.send "host #{host_id} retired"

--- a/src/mackerel.coffee
+++ b/src/mackerel.coffee
@@ -87,5 +87,5 @@ module.exports = (robot) ->
           else
             hosts_text = ""
             for k,v of response['hosts']
-              hosts_text += v['name'] + "\n" + process.env.HUBOT_MACKEREL_URL_BASE + v['id'] + "\n\n"
+              hosts_text += "#{v['name']} - #{v['id']}" + "\n" + process.env.HUBOT_MACKEREL_URL_BASE + v['id'] + "\n\n"
             msg.send hosts_text

--- a/src/mackerel.coffee
+++ b/src/mackerel.coffee
@@ -3,8 +3,7 @@
 #
 # Commands:
 #   hubot mackerel hosts - show all hosts and graph urls
-#   hubot mackerel hosts service <service> - show hosts and graph urls filterd by specified service
-#   hubot mackerel hosts service <service> role <role> - show hosts and graph urls filterd by specified service and role
+#   hubot mackerel hosts [service <service>] [role <role>] [name <name>] [status <status>] - show hosts and graph urls filterd by specified service, role, name or status
 #
 # Author:
 #   mdoi
@@ -70,6 +69,14 @@ module.exports = (robot) ->
       if optionMatch?
         addQueryString = true
         queryStringArray.push('role=' + optionMatch[1])
+      optionMatch = /name\s+(\S+)/.exec(options)
+      if optionMatch?
+        addQueryString = true
+        queryStringArray.push('name=' + optionMatch[1])
+      optionMatch = /status\s+(\S+)/.exec(options)
+      if optionMatch?
+        addQueryString = true
+        queryStringArray.push('status=' + optionMatch[1])
       if addQueryString
         queryString = '?' + queryStringArray.join('&')
     msg.http(process.env.HUBOT_MACKEREL_API_ENDPOINT + "hosts.json" + queryString)


### PR DESCRIPTION
I've added some features below.
- supported the `name` and `status` query parameters of host list search
  - http://help-ja.mackerel.io/entry/spec/api/v0#hosts-list
- supported the update api of host status
  - http://help-ja.mackerel.io/entry/spec/api/v0#host-status-update
- supported the retire api
  - http://help-ja.mackerel.io/entry/spec/api/v0#host-retire
- supported the get api of a host
  - http://help-ja.mackerel.io/entry/spec/api/v0#host-get
- added hostId to the result of `hubot mackerel hosts`

Could you please merge if these changes makes sense?
